### PR TITLE
Give atmo user passwordless sudo

### DIFF
--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -25,4 +25,4 @@
   file: path=/root/.ssh/ state=directory mode="0700"
 
 # Fully quoted because of the ': ' on the line
-- lineinfile: "dest=/etc/sudoers state=present line='{{ ATMOUSERNAME }}  ALL = (ALL) NOPASSWD: ALL'"
+- lineinfile: "dest=/etc/sudoers state=present validate='visudo -cf %s' line='{{ ATMOUSERNAME }}  ALL = (ALL) NOPASSWD: ALL'"

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -23,3 +23,6 @@
 
 - name: make sure ssh directory exists
   file: path=/root/.ssh/ state=directory mode="0700"
+
+# Fully quoted because of the ': ' on the line
+- lineinfile: "dest=/etc/sudoers state=present line='{{ ATMOUSERNAME }}  ALL = (ALL) NOPASSWD: ALL'"


### PR DESCRIPTION
I'm not sure if this is the best location. There was a comment that this playbook was responsible for setting up `/etc/sudoers`.

I have not tested this playbook change. I'm confident about the line it adds.